### PR TITLE
本番環境のRedis URLの修正

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,15 +3,16 @@
 :queues:
   - default
   - critical
+  - mailer
 
 scheduler:
   schedule:
     fetch_twitch_clips_job:
-      cron: "0 0 * * *"   # 毎日0時に実行
+      cron: "0 0 * * *"
       class: FetchTwitchClipsJob
       queue: default
 
     fetch_japanese_streamers_job:
-      cron: "0 */2 * * *" # 2時間おきに実行
+      cron: "0 */2 * * *"
       class: FetchJapaneseStreamersJob
       queue: default

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -1,7 +1,7 @@
 scheduler:
   schedule:
     fetch_japanese_streamers_job:
-      cron: "0 */2 * * *" # 2時間おきに実行
+      cron: "0 */2 * * *"
       class: FetchJapaneseStreamersJob
       queue: default
     fetch_twitch_clips_job:

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-# fly.toml app configuration file generated for clipfinder on 2024-09-28T20:54:03+09:00
+# fly.toml app configuration file generated for favoriteclipfinder on 2024-09-28T20:54:03+09:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #


### PR DESCRIPTION
## 変更の概要

* 変更の概要
* 関連するIssueやプルリクエスト
* 本番環境でJOBが定期実行されないバグを修正する
* #156 

## なぜこの変更をするのか

* 変更をする理由
* 前提知識がなくても分かるようにする
* JOBが定期実行されず、自動でクリップ取得と配信者取得ができないため修正する

## やったこと

* [x] やったこと
* [x] 本番環境のRedisのURLを前回のアプリのURLのままにしてしまっていたため、現在のアプリのURLに書き換えた