### PR TITLE
search_controller rspec 完成

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,17 +1,26 @@
 # app/controllers/search_controller.rb
 class SearchController < ApplicationController
   def index
+    # 検索フォームの値を取得
     if params[:q].present?
+
+      # includeで関連テーブルを取得
       @q = Clip.includes(:streamer, :game).ransack(
+        # 複数の検索条件をORで結合
         combinator: "or",
+        # ゲーム名を含む
         game_name_cont: params[:q],
-        streamer_name_cont: params[:q],
+        # 配信者名を含む
+        streamer_streamer_name_cont: params[:q],
+        # 配信者の表示名を含む
         streamer_display_name_cont: params[:q]
       )
     else
+      # キーワードがない場合は全てのクリップを取得
       @q = Clip.includes(:streamer, :game).ransack({})
     end
 
+    # @qを使って、検索結果を取得
     @clips = @q.result(distinct: true).order(clip_created_at: :desc).page(params[:page]).per(60)
 
     # ログインしている場合のみプレイリストを渡す
@@ -19,7 +28,7 @@ class SearchController < ApplicationController
   end
 
   def playlist
-    # プレイリスト取得
+    # いいね数が多い順にプレイリスト取得
     @playlists = Playlist.where(visibility: "public").includes(:user).order(likes_count: :desc)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,8 @@
         <%= text_field_tag :q, params[:q], 
           data: { autocomplete_target: 'input' },
           class: "w-full bg-transparent py-1 px-2 text-gray-700 placeholder-gray-400",
-          placeholder: "検索" %>
+          placeholder: "検索",
+          required: "required" %>
         <ul class="list-group bg-white absolute w-full md:text-sm max-w-max border border-gray-300 rounded-md shadow-lg z-10 mt-1" data-autocomplete-target="results"></ul>
       </div>
       <!-- 検索アイコン -->

--- a/spec/system/searches_spec.rb
+++ b/spec/system/searches_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe "Searches", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  describe '検索ページ（SearchController#index）' do
+    context '検索フォームに値を入力した場合' do
+      let!(:game) { create(:game) }
+      let!(:game_clip) { create(:clip, game: game) }
+      let!(:streamer) { create(:streamer) }
+      let!(:streamer_clip) { create(:clip, streamer: streamer) }
+      let!(:streamer_display_name_clip) { create(:clip, streamer: streamer) }
+
+      it 'ゲーム名を入力した場合ゲーム名のクリップが表示されること' do
+        visit search_path
+        fill_in 'q', with: game.name
+        find('button[type="submit"]').click
+        expect(page).to have_content(game_clip.title)
+      end
+
+      it '配信者名を入力した場合配信者名のクリップが表示されること' do
+        visit search_path
+        fill_in 'q', with: streamer.streamer_name
+        find('button[type="submit"]').click
+        expect(page).to have_content(streamer_clip.title)
+      end
+
+      it '配信者の表示名を入力した場合配信者名のクリップが表示されること' do
+        visit search_path
+        fill_in 'q', with: streamer.display_name
+        find('button[type="submit"]').click
+        expect(page).to have_content(streamer_display_name_clip.title)
+      end
+
+      it '検索フォームに不当な値を入力した場合、エラー画面が表示されること' do
+        visit search_path
+        fill_in 'q', with: '不当な値'
+        find('button[type="submit"]').click
+        expect(page).to have_content("現在のキーワードに該当するクリップが存在しておりません")
+      end
+    end
+  end
+
+  describe 'プレイリストページ（SearchController#playlist）' do
+    context 'プレイリストページに遷移した場合' do
+      let!(:user) { create(:user) }
+      let!(:user2) { create(:user) }
+      let!(:user3) { create(:user) }
+      let!(:user4) { create(:user) }
+      let!(:user5) { create(:user) }
+      let!(:user6) { create(:user) }
+
+      # 公開済みのプレイリストを作成
+      let!(:public_playlist) do
+        playlist = create(:playlist, visibility: 'public', user: user)
+        clip = create(:clip)
+        create(:playlist_clip, playlist: playlist, clip: clip)
+      end
+      # 非公開のプレイリストを作成
+      let!(:private_playlist) do
+        playlist = create(:playlist, visibility: 'private', user: user)
+        clip = create(:clip)
+        create(:playlist_clip, playlist: playlist, clip: clip)
+      end
+
+      # いいね数が3のプレイリストを作成
+      let!(:playlist_3_likes_playlist) do
+        playlist_like_three = create(:playlist, user: user2)
+        create(:like, user: user, playlist: playlist_like_three)
+        create(:like, user: user3, playlist: playlist_like_three)
+        create(:like, user: user4, playlist: playlist_like_three)
+        clip = create(:clip)
+        create(:playlist_clip, playlist: playlist_like_three, clip: clip)
+      end
+
+      # いいね数が2のプレイリストを作成
+      let!(:playlist_2_likes_playlist) do
+        playlist_like_two = create(:playlist, user: user3)
+        create(:like, user: user, playlist: playlist_like_two)
+        create(:like, user: user2, playlist: playlist_like_two)
+        create(:like, user: user3, playlist: playlist_like_two)
+        create(:playlist_clip, playlist: playlist_like_two, clip: create(:clip))
+      end
+
+      # いいね数が1のプレイリストを作成
+      let!(:playlist_1_likes_playlist) do
+        playlist_like_one = create(:playlist, user: user4)
+        create(:like, user: user, playlist: playlist_like_one)
+        create(:like, user: user2, playlist: playlist_like_one)
+        create(:like, user: user3, playlist: playlist_like_one)
+        create(:playlist_clip, playlist: playlist_like_one, clip: create(:clip))
+      end
+
+      it '公開プレイリストのみが表示されること' do
+        visit search_playlist_path
+        expect(page).to have_content(public_playlist.playlist.title)
+        expect(page).not_to have_content(private_playlist.playlist.title)
+      end
+
+      it 'いいね数が多い順にプレイリストが表示されること' do
+        visit search_playlist_path
+        # いいね数順にぷれいりすとが表示されていること
+        expect(page).to have_content(playlist_3_likes_playlist.playlist.title)
+        expect(page).to have_content(playlist_2_likes_playlist.playlist.title)
+        expect(page).to have_content(playlist_1_likes_playlist.playlist.title)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

searchControllerのシステムスペックを完成させる

## テスト

- searchController#index
  - 検索フォームに値を入力した場合
    - ゲーム名を入力した場合ゲーム名のクリップが表示されること
    - 配信者名を入力した場合配信者名のクリップが表示されること
    - 配信者の表示名を入力した場合配信者の表示名のクリップが表示されること
    - 検索フォームに不当な値を入力した場合、エラー画面が表示されること
 - searchController#playlist
   - プレイリストページに遷移した場合
     - 公開プレイリストのみが表示されること
     - いいね数が多い順にプレイリストが表示されること  